### PR TITLE
Change ToString to use original rather than foldedCase

### DIFF
--- a/src/Data/String/ToString.hs
+++ b/src/Data/String/ToString.hs
@@ -4,7 +4,7 @@
   #-}
 module Data.String.ToString (ToString (..)) where
 
-import Data.CaseInsensitive (CI, foldedCase)
+import Data.CaseInsensitive (CI, original)
 import qualified Data.ByteString.Lazy.UTF8 as LBU
 import qualified Data.ByteString.UTF8      as SBU
 import qualified Data.Text                 as ST
@@ -29,4 +29,4 @@ instance ToString LT.Text where
   toString = LT.unpack
 
 instance ToString s => ToString (CI s) where
-  toString = toString . foldedCase
+  toString = toString . original


### PR DESCRIPTION
Is there a reason behind using `foldedCase`? It's unintuitive to me as e.g. `toString . mk` isn't the identity.

If we change this I think it calls for a major bump.
